### PR TITLE
Fix invalid config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ You can add the following configuration params to your `book.json`:
 		"simple-page-toc": {
 			"maxDepth": 3,
 			"skipFirstH1": true
-   }
-}		
+   	}
+  }
+}			
 ```
 
 Name        | Type    | Default | Description 


### PR DESCRIPTION
The brackets for `pluginConfig` are not closed. I copy and pasted it and Gitbook gives `SyntaxError: blabla/book.json: Unexpected end of JSON input`
